### PR TITLE
SDK Compatibility updates

### DIFF
--- a/fast-point-cloud-segmentation.ipynb
+++ b/fast-point-cloud-segmentation.ipynb
@@ -41,7 +41,9 @@
       "source": [
         "We'll start by installing the Python SDK and cloning the demo repository from Github.\n",
         "\n",
-        "If you're using Colab, be sure to use a GPU-powered runtime, so you can run the segmentation model later. You can change your runtype by clicking on `Runtime > Change runtime type` in the top bar."
+        "If you're using Colab, be sure to use a GPU-powered runtime, so you can run the segmentation model later. You can change your runtype by clicking on `Runtime > Change runtime type` in the top bar.\n",
+        "\n",
+        "**Note**: this notebook is not compatible with python 3.12 and upwards. Don't worry, the segments SDK is compatible with newer python versions, but the model we use in step 3 is not."
       ]
     },
     {
@@ -100,11 +102,11 @@
       "outputs": [],
       "source": [
         "clone = client.clone_dataset(\n",
-        "    \"admin-tobias/semantickitti\",\n",
+        "    \"segments/semantickitti\",\n",
         "    new_name=\"fast-labeling-semantickitti\",\n",
         "    new_public=False,\n",
         ")\n",
-        "dataset_identifier = f\"{clone.owner}/{clone.name}\""
+        "dataset_identifier = clone.full_name"
       ]
     },
     {
@@ -438,7 +440,7 @@
         "with open(f\"path/to/{filename}\", \"rb\") as f:\n",
         "    asset = client.upload_asset(f, filename=filename)\n",
         "\n",
-        "point_cloud_url = asset[\"url\"]"
+        "point_cloud_url = asset.url"
       ]
     },
     {
@@ -449,7 +451,7 @@
       },
       "outputs": [],
       "source": [
-        "dataset = \"tobias-admin/my-point-clouds\"\n",
+        "dataset_identifier = dataset.full_name\n",
         "\n",
         "name = \"ca9a282c9e77460f8360f564131a8af5_nuscenes\"\n",
         "\n",
@@ -457,7 +459,7 @@
         "    \"pcd\": {\"url\": point_cloud_url, \"type\": \"nuscenes\"},\n",
         "}\n",
         "\n",
-        "sample = client.add_sample(dataset, name, attributes)"
+        "sample = client.add_sample(dataset_identifier, name, attributes)"
       ]
     }
   ],
@@ -486,7 +488,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.8.10"
+      "version": "3.11.9"
     }
   },
   "nbformat": 4,

--- a/utils.py
+++ b/utils.py
@@ -92,15 +92,11 @@ def get_kitti_attributes():
 
 
 def run_model(dataset_path, output_path):
-    dataset_path = os.path.join(os.path.abspath(sys.path[0]), dataset_path)
-    output_path = os.path.join(os.path.abspath(sys.path[0]), output_path)
-    model_path = os.path.join(os.path.abspath(sys.path[0]), "SSGV3-53")
-    script_path = os.path.join(
-        os.path.abspath(sys.path[0]), "SqueezeSegV3/src/tasks/semantic/demo.py"
-    )
-    wd_path = os.path.join(
-        os.path.abspath(sys.path[0]), "SqueezeSegV3/src/tasks/semantic"
-    )
+    dataset_path = os.path.abspath(dataset_path)
+    output_path = os.path.abspath(output_path)
+    model_path = os.path.abspath("SSGV3-53")
+    script_path = os.path.abspath("SqueezeSegV3/src/tasks/semantic/demo.py")
+    wd_path = os.path.abspath("SqueezeSegV3/src/tasks/semantic")
 
     subprocess.call(
         [


### PR DESCRIPTION
There are a few fixes required to get this notebook working again. This PR contains the following: 
 - Changed how the dataset identifier is resolved, now uses `Dataset.full_name`
 - The notebook does not work for python3.12. I've added a (text) warning at the top of the notebook. This requirement exists because SqueezeSegV3 uses `imp`, which is deprecated.
 - The way the absolute paths were resolved in `utils.train_model` did not work on my setup. `sys.path[0]` pointed a folder "/usr/lib". I've changed it to just resolve the relative path you give to the `train_model` function. 
 - I changed the clone dataset_id to "segments/semantickitti", the old one does not exist anymore.